### PR TITLE
Issues and testId patterns can now be defined in pom file

### DIFF
--- a/src/main/java/ru/yandex/qatools/allure/report/AllureGenerateMojo.java
+++ b/src/main/java/ru/yandex/qatools/allure/report/AllureGenerateMojo.java
@@ -60,6 +60,18 @@ public abstract class AllureGenerateMojo extends AllureResolveMojo {
     protected String allureMain;
 
     /**
+     * Path for @Issues
+     */
+    @Parameter
+    protected String issuesPattern;
+
+    /**
+     * Path for @Story
+     */
+    @Parameter
+    protected String testIdPattern;
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -85,6 +97,16 @@ public abstract class AllureGenerateMojo extends AllureResolveMojo {
             if (inputDirectories.isEmpty()) {
                 getLog().warn("Allure report was skipped because there is no results directories found.");
                 return;
+            }
+
+            if (issuesPattern != null){
+                System.setProperty("allure.issues.tracker.pattern" , issuesPattern);
+                getLog().info("allure.issues.tracker.pattern set to: " + issuesPattern);
+            }
+
+            if (testIdPattern != null){
+                System.setProperty("allure.tests.management.pattern" , testIdPattern);
+                getLog().info("allure.tests.management.pattern set to: " + testIdPattern);
             }
 
             List<String> parameters = new ArrayList<>();


### PR DESCRIPTION
I'd like to configure Issue Tracker and TestCaseId in Allure so that they numbers in reports are converted into valid URLs, by changing POM file so that I don't need to ask CI/CD teams to change command line params.

With this change we may do it like:
```
<configuration>
    <testIdPattern>http://testcases.com/test/%s</testIdPattern>
    <issuesPattern>http://issues.com/id/%s</issuesPattern>
</configuration>
```